### PR TITLE
add(workflows): add update-contributor-leaderboard workflow

### DIFF
--- a/.github/workflows/update-contributor-leaderboard.yml
+++ b/.github/workflows/update-contributor-leaderboard.yml
@@ -1,0 +1,24 @@
+name: Update Contributor Leaderboard
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Update everyday at 00:00 UTC
+
+  workflow_dispatch: # Manually trigger the update
+
+jobs:
+  update-leaderboard:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Update Leaderboard
+        uses: kristof-low/github-contributor-leaderboard@v1
+        with:
+          commit-message: "docs(readme): update contributor leaderboard"
+

--- a/README.md
+++ b/README.md
@@ -95,3 +95,8 @@ We proudly credit all community members who contribute entries, edits, or feedba
 [<img src="https://avatars.githubusercontent.com/u/19947758" width="70px;"/>](https://github.com/ajitzero/)
 
 Want to see your name here? Start contributing!
+
+### 🏆 Contributor Leaderboard
+
+<!-- leaderboard-start -->
+<!-- leaderboard-end -->


### PR DESCRIPTION
I saw the _help-wanted_ label on issue #20 and thought I'd give it a try.

Let me know if anything should change. For example,
- formatting,
- placement,
- commit message used,
- number of contributors shown,
- to exclude bots,
- logic used to determine ranking (currently, only # of contributions is used),
- when to update the leaderboard, etc.

closes #20.