### PR TITLE
fix(workflows): fix leaderboard workflow to respect branch rulesets

### DIFF
--- a/.github/workflows/update-contributor-leaderboard.yml
+++ b/.github/workflows/update-contributor-leaderboard.yml
@@ -12,6 +12,7 @@ jobs:
 
     permissions:
       contents: write
+      pull-requests: write
 
     env:
       GH_TOKEN: ${{ github.token }}
@@ -21,4 +22,5 @@ jobs:
         uses: kristof-low/github-contributor-leaderboard@v1
         with:
           commit-message: "docs(readme): update contributor leaderboard"
+          use-pull-request: "true"
 

--- a/.github/workflows/update-contributor-leaderboard.yml
+++ b/.github/workflows/update-contributor-leaderboard.yml
@@ -12,7 +12,6 @@ jobs:
 
     permissions:
       contents: write
-      pull-requests: write
 
     env:
       GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Due to the 'main' branch's branch protection rules, the [update-contributor-leaderboard](https://github.com/ng-delhi/we-use-angular/blob/main/.github/workflows/update-contributor-leaderboard.yml) workflow is [currently failing everytime](https://github.com/ng-delhi/we-use-angular/actions/runs/14721704170/job/41316596330) since it tries to push to main which only accepts pull-requests:
```
remote: error: GH006: Protected branch update failed for refs/heads/main.        
remote: 
remote: - Changes must be made through a pull request.  
```

This pull-request updates the workflow to specify that a pull-request must be created, hopefully fixing the issue.