### PR TITLE
fix(workflows): update leaderboard workflow's permissions

### DIFF
--- a/.github/workflows/update-contributor-leaderboard.yml
+++ b/.github/workflows/update-contributor-leaderboard.yml
@@ -12,6 +12,7 @@ jobs:
 
     permissions:
       contents: write
+      pull-requests: write
 
     env:
       GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
I added the `pull-requests: write` permission to the leaderboard workflow to enable the action used to create a pull-request with the updated `README.md`. This should fix what caused the [initial run](https://github.com/ng-delhi/we-use-angular/actions/runs/14745077347/job/41390762634) to fail:
```bash
pull request create failed: GraphQL: Resource not accessible by integration (createPullRequest)
```
The other issue resulting in the [subsequent runs](https://github.com/ng-delhi/we-use-angular/actions/runs/14806336712/job/41575108159) failing was dealt with in the action (by force pushing to the source branch of the pull-request, i.e., [update(docs)/update-contributor-leaderboard](https://github.com/ng-delhi/we-use-angular/tree/update(docs)/update-contributor-leaderboard), if it still exists on the remote).

Everything seems to work on my fork, so I believe all should be good, but let me know if there are any other issues and/or suggestions.