### PR TITLE
feat(cua): add icons to tech stack in company card

### DIFF
--- a/src/app/core/components/company-card.ts
+++ b/src/app/core/components/company-card.ts
@@ -63,5 +63,4 @@ export class CompanyCardComponent {
   getIconsClass(tech: string): string {
     return TECH_ICON_CLASSES[tech.toLowerCase()] || '';
   }
-
 }

--- a/src/app/core/components/company-card.ts
+++ b/src/app/core/components/company-card.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
 import { Company } from '../types/company';
 import { ThemeService } from '../services/theme';
+import { TECH_ICON_CLASSES } from '../types/techiconmapping';
 
 @Component({
   selector: 'company-card',
@@ -18,6 +19,7 @@ import { ThemeService } from '../services/theme';
               <span
                 class="px-2 py-1 text-xs font-medium text-gray-800 bg-gray-100 rounded-xl dark:bg-gray-800 dark:text-gray-200"
               >
+                <i [class]="getIconsClass(tech)"></i>
                 {{ tech }}
               </span>
             }
@@ -57,4 +59,9 @@ import { ThemeService } from '../services/theme';
 export class CompanyCardComponent {
   company = input.required<Company>();
   readonly themeService = inject(ThemeService);
+
+  getIconsClass(tech: string): string {
+    return TECH_ICON_CLASSES[tech.toLowerCase()] || '';
+  }
+
 }

--- a/src/app/core/types/techiconmapping.ts
+++ b/src/app/core/types/techiconmapping.ts
@@ -3,11 +3,11 @@ export type TechstackIconClass = {
 };
 
 export const TECH_ICON_CLASSES: TechstackIconClass = {
-  'angular': 'ri-angularjs-line',
-  'angularjs': 'ri-angularjs-line',
-  'react': 'ri-reactjs-line',
+  angular: 'ri-angularjs-line',
+  angularjs: 'ri-angularjs-line',
+  react: 'ri-reactjs-line',
   'node.js': 'ri-nodejs-line',
-  'java': 'ri-java-line',
-  'javascript': 'ri-javascript-line',
-  'firebase': 'ri-firebase-line'
+  java: 'ri-java-line',
+  javascript: 'ri-javascript-line',
+  firebase: 'ri-firebase-line',
 };

--- a/src/app/core/types/techiconmapping.ts
+++ b/src/app/core/types/techiconmapping.ts
@@ -1,0 +1,13 @@
+export type TechstackIconClass = {
+  [techName: string]: string;
+};
+
+export const TECH_ICON_CLASSES: TechstackIconClass = {
+  'angular': 'ri-angularjs-line',
+  'angularjs': 'ri-angularjs-line',
+  'react': 'ri-reactjs-line',
+  'node.js': 'ri-nodejs-line',
+  'java': 'ri-java-line',
+  'javascript': 'ri-javascript-line',
+  'firebase': 'ri-firebase-line'
+};

--- a/src/index.html
+++ b/src/index.html
@@ -6,14 +6,13 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
-      integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
-    />
-  </head>
+
+  
+  
+  <link
+    href="https://cdn.jsdelivr.net/npm/remixicon@4.5.0/fonts/remixicon.css"
+    rel="stylesheet"
+/></head>
   <body>
     <app-root></app-root>
   </body>

--- a/src/index.html
+++ b/src/index.html
@@ -7,12 +7,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
 
-  
-  
-  <link
-    href="https://cdn.jsdelivr.net/npm/remixicon@4.5.0/fonts/remixicon.css"
-    rel="stylesheet"
-/></head>
+    <link
+      href="https://cdn.jsdelivr.net/npm/remixicon@4.5.0/fonts/remixicon.css"
+      rel="stylesheet"
+    />
+  </head>
   <body>
     <app-root></app-root>
   </body>


### PR DESCRIPTION
Solution description:
1. The icon library Remix icon (https://remixicon.com/) added through index.html 
2. Created interface TECH_ICON_CLASSES with type TechstackIconClass for mapping of custom classes.
3. The custom classes for icons are applied as per tech stack names which can be modified in file techiconmapping.ts